### PR TITLE
Fix flickering on resize

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ import {
 } from './src/reconciler'
 
 const apply = (objects: object): void => {
-  console.warn('react-three-fiber: Please use extend instead of apply, the former will be made obsolete soon!')
+  console.warn('react-three-fiber: Please use extend ✅ instead of apply ❌, the former will be made obsolete soon!')
   extend(objects)
 }
 

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ import {
 } from './src/reconciler'
 
 const apply = (objects: object): void => {
-  console.warn('react-three-fiber: Please use extend ✅ instead of apply ❌, the former will be made obsolete soon!')
+  console.warn('react-three-fiber: Please use extend instead of apply, the former will be made obsolete soon!')
   extend(objects)
 }
 

--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -277,6 +277,8 @@ export const Canvas = React.memo(
           state.current.camera.updateProjectionMatrix()
         }
         invalidate(state)
+        //Must render once more for resizing events to prevent flicker
+        defaultRenderer.render(defaultScene, defaultCam)
       }
       // Only trigger the context provider when necessary
       sharedState.current = { ...state.current }


### PR DESCRIPTION
After applying the size change, render must be called immediately, otherwise the canvas is cleared and flickers white or its bg color. This should resolve #179 and I believe addressed in a threejs issue list as well, which is where I got this idea.

The issue was only happening on Microsoft browsers like Edge and IE11