### PR TITLE
fix: get gl from state

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -220,9 +220,9 @@ export const useCanvas = (props: UseCanvasProps): { pointerEvents: PointerEvents
   useEffect(() => {
     // Dispose renderer on unmount
     return () => {
-      if (gl) {
-        gl.forceContextLoss!()
-        gl.dispose!()
+      if (state.current.gl) {
+        state.current.gl.forceContextLoss!()
+        state.current.gl.dispose!()
         ;(state.current as any).gl = undefined
         state.current.active = false
         unmountComponentAtNode(state.current.scene)


### PR DESCRIPTION
Found a very important bug where the `gl` variable seem to be lost on dispose, but is somehow available from the state.

I was creating react native examples app and when navigating back and forth between examples, I noticed that the roots kept filling up, decreasing performance.