### PR TITLE
feature: three controls state

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -54,6 +54,8 @@ export type CanvasContext = {
   viewport: { width: number; height: number; factor: number }
   initialClick: [number, number]
   initialHits: THREE.Object3D[]
+  controls?: any
+  setControls(controls: any): void
 }
 
 export type CanvasProps = {
@@ -99,13 +101,18 @@ export type UseCanvasProps = {
   onPointerMissed?: () => void
 }
 
+type CanvasResult = {
+  pointerEvents: PointerEvents
+  context: CanvasContext
+}
+
 function makeId(event: THREE.Intersection) {
   return event.object.uuid + '/' + event.index
 }
 
 export const stateContext = createContext<CanvasContext>({} as CanvasContext)
 
-export const useCanvas = (props: UseCanvasProps): { pointerEvents: PointerEvents } => {
+export const useCanvas = (props: UseCanvasProps): CanvasResult => {
   const {
     children,
     gl,
@@ -171,7 +178,7 @@ export const useCanvas = (props: UseCanvasProps): { pointerEvents: PointerEvents
     viewport: { width: 0, height: 0, factor: 0 },
     initialClick: [0, 0],
     initialHits: [],
-
+    setControls: controls => void (state.current.controls = controls),
     subscribe: (fn: RenderCallback) => {
       state.current.subscribers.push(fn)
       return () => (state.current.subscribers = state.current.subscribers.filter(s => s !== fn))
@@ -467,6 +474,7 @@ export const useCanvas = (props: UseCanvasProps): { pointerEvents: PointerEvents
   }, [])
 
   return {
+    context: state.current,
     pointerEvents: {
       onClick: handlePointer('click'),
       onWheel: handlePointer('wheel'),

--- a/src/targets/native/canvas.tsx
+++ b/src/targets/native/canvas.tsx
@@ -11,14 +11,17 @@ function clientXY(e: GestureResponderEvent) {
   return e
 }
 
-export const Canvas = React.memo((props: CanvasProps & { style?: ViewStyle }) => {
+type NativeCanvasProps = {
+  style?: ViewStyle
+}
+
+export const Canvas = React.memo((props: CanvasProps & NativeCanvasProps) => {
   const [gl, setGl] = useState()
   const [glContext, setGlContext] = useState()
-
   const [pixelRatio, setPixelRatio] = useState(props.pixelRatio || 1)
   const [size, setSize] = useState({ width: 0, height: 0, top: 0, left: 0 })
 
-  const { pointerEvents } = useCanvas({
+  const { pointerEvents, context } = useCanvas({
     ...props,
     size,
     pixelRatio,
@@ -43,9 +46,18 @@ export const Canvas = React.memo((props: CanvasProps & { style?: ViewStyle }) =>
       onPanResponderTerminationRequest() {
         return true
       },
-      onPanResponderStart: e => pointerEvents.onPointerDown(clientXY(e)),
-      onPanResponderMove: e => pointerEvents.onPointerMove(clientXY(e)),
-      onPanResponderEnd: e => pointerEvents.onPointerUp(clientXY(e)),
+      onPanResponderStart: e => {
+        context.controls && context.controls.onTouchStart(e.nativeEvent)
+        pointerEvents.onPointerDown(clientXY(e))
+      },
+      onPanResponderMove: e => {
+        context.controls && context.controls.onTouchMove(e.nativeEvent)
+        pointerEvents.onPointerMove(clientXY(e))
+      },
+      onPanResponderEnd: e => {
+        context.controls && context.controls.onTouchEnd(e.nativeEvent)
+        pointerEvents.onPointerUp(clientXY(e))
+      },
       onPanResponderRelease: e => pointerEvents.onPointerLeave(clientXY(e)),
       onPanResponderTerminate: e => pointerEvents.onLostPointerCapture(clientXY(e)),
       onPanResponderReject: e => pointerEvents.onLostPointerCapture(clientXY(e)),

--- a/src/targets/native/canvas.tsx
+++ b/src/targets/native/canvas.tsx
@@ -47,15 +47,21 @@ export const Canvas = React.memo((props: CanvasProps & NativeCanvasProps) => {
         return true
       },
       onPanResponderStart: e => {
-        context.controls && context.controls.onTouchStart(e.nativeEvent)
+        if (context.controls && context.controls.onTouchStart) {
+          context.controls.onTouchStart(e.nativeEvent)
+        }
         pointerEvents.onPointerDown(clientXY(e))
       },
       onPanResponderMove: e => {
-        context.controls && context.controls.onTouchMove(e.nativeEvent)
+        if (context.controls && context.controls.onTouchMove) {
+          context.controls && context.controls.onTouchMove(e.nativeEvent)
+        }
         pointerEvents.onPointerMove(clientXY(e))
       },
       onPanResponderEnd: e => {
-        context.controls && context.controls.onTouchEnd(e.nativeEvent)
+        if (context.controls && context.controls.onTouchEnd) {
+          context.controls && context.controls.onTouchEnd(e.nativeEvent)
+        }
         pointerEvents.onPointerUp(clientXY(e))
       },
       onPanResponderRelease: e => pointerEvents.onPointerLeave(clientXY(e)),


### PR DESCRIPTION
[DISCUSSION/IDEA]

This PR adds the ability to set a single control object to the canvas state via `setControls` from useThree.

This can become handy if you need to reference your controls of choice (OrbitControls/FirstPersonControls/etc) between components without create your own context.

But this is first and foremost used to allow the native target to set touch events from the PanResponder and directly manipulate the controls.

Does anyone have a better idea to do this?