### PR TITLE
Fix calculation of mouse event inside raycaster v2

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -41,6 +41,10 @@ export interface RectReadOnly {
   readonly left: number
 }
 
+export type BoundingClientRectRef = {
+  readonly current: RectReadOnly
+}
+
 export type SharedCanvasContext = {
   gl: THREE.WebGLRenderer
   aspect: number
@@ -103,6 +107,7 @@ export type CanvasProps = {
 export type UseCanvasProps = CanvasProps & {
   gl: THREE.WebGLRenderer
   size: RectReadOnly
+  rayBounds: BoundingClientRectRef
 }
 
 export type PointerEvents = {
@@ -130,6 +135,7 @@ export const useCanvas = (props: UseCanvasProps): PointerEvents => {
     orthographic,
     raycaster,
     size,
+    rayBounds,
     pixelRatio,
     vr = false,
     shadowMap = false,
@@ -356,15 +362,9 @@ export const useCanvas = (props: UseCanvasProps): PointerEvents => {
       //   y -= event.target.offsetParent.offsetTop
       // }
 
-      const { left, right, top, bottom } = state.current.size
-      let { clientX, clientY } = event
+      const { left, right, top, bottom } = rayBounds.current
 
-      if (typeof window !== 'undefined') {
-        clientX += window.pageXOffset
-        clientY += window.pageYOffset
-      }
-
-      mouse.set(((clientX - left) / (right - left)) * 2 - 1, -((clientY - top) / (bottom - top)) * 2 + 1)
+      mouse.set(((event.clientX - left) / (right - left)) * 2 - 1, -((event.clientY - top) / (bottom - top)) * 2 + 1)
       defaultRaycaster.setFromCamera(mouse, state.current.camera)
     }
   }, [])

--- a/src/targets/native/canvas.tsx
+++ b/src/targets/native/canvas.tsx
@@ -30,7 +30,7 @@ type NativeCanvasProps = Omit<CanvasProps, 'style'> & {
 const styles: ViewStyle = { flex: 1 }
 
 const IsReady = React.memo(({ gl, ...props }: NativeCanvasProps & { gl: any; size: any }) => {
-  const events = useCanvas({ ...props, gl } as UseCanvasProps)
+  const events = useCanvas({ ...props, gl, rayBounds: { current: props.size } } as UseCanvasProps)
 
   let pointerDownCoords: null | [number, number] = null
 

--- a/src/targets/web/canvas.tsx
+++ b/src/targets/web/canvas.tsx
@@ -2,9 +2,9 @@ import * as THREE from 'three'
 import * as React from 'react'
 import { useRef, useEffect, useState, useMemo } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
-import { useCanvas, CanvasProps, RectReadOnly, PointerEvents } from '../../canvas'
+import { useCanvas, CanvasProps, RectReadOnly, BoundingClientRectRef, PointerEvents } from '../../canvas'
 
-type Measure = [React.MutableRefObject<HTMLDivElement | null>, RectReadOnly]
+type Measure = [React.MutableRefObject<HTMLDivElement | null>, RectReadOnly, BoundingClientRectRef]
 
 function useMeasure(): Measure {
   const ref = useRef<HTMLDivElement>(null)
@@ -19,27 +19,42 @@ function useMeasure(): Measure {
     y: 0,
   })
   const [ro] = useState(
-    () =>
-      new ResizeObserver(() => {
-        if (!ref.current) return
-        const { pageXOffset, pageYOffset } = window
-        const { left, top, width, height, bottom, right, x, y } = ref.current.getBoundingClientRect() as RectReadOnly
-        const size = { left, top, width, height, bottom, right, x, y }
-        size.top += pageYOffset
-        size.bottom += pageYOffset
-        size.y += pageYOffset
-        size.left += pageXOffset
-        size.right += pageXOffset
-        size.x += pageXOffset
-        Object.freeze(size)
-        return set(size)
-      })
+    () => new ResizeObserver(() => ref.current && set(ref.current.getBoundingClientRect() as RectReadOnly))
   )
   useEffect(() => {
     if (ref.current) ro.observe(ref.current)
     return () => ro.disconnect()
   }, [])
-  return [ref, bounds]
+
+  const shouldRecalc = useRef<boolean>(false)
+  const scrollBounds = useMemo(
+    () => ({
+      _cache: bounds,
+      get current() {
+        if (shouldRecalc.current) {
+          shouldRecalc.current = false
+          this._cache = (ref.current as HTMLDivElement).getBoundingClientRect() as RectReadOnly
+        }
+
+        return this._cache
+      },
+    }),
+    [bounds]
+  )
+
+  useEffect(() => {
+    const onScroll = (event: Event) => {
+      // Skip the check if flag already set
+      if (shouldRecalc.current) return
+      shouldRecalc.current = (event.target as HTMLElement).contains(ref.current as Node)
+    }
+
+    window.addEventListener('scroll', onScroll, { capture: true, passive: true })
+
+    return () => window.removeEventListener('scroll', onScroll, true)
+  }, [])
+
+  return [ref, bounds, scrollBounds]
 }
 
 const IsReady = React.memo(
@@ -51,6 +66,7 @@ const IsReady = React.memo(
     setEvents: React.Dispatch<React.SetStateAction<PointerEvents>>
     canvas: HTMLCanvasElement
     size: RectReadOnly
+    rayBounds: BoundingClientRectRef
   }) => {
     const gl = useMemo(() => new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true, ...props.gl }), [])
 
@@ -84,7 +100,7 @@ export const Canvas = React.memo((props: CanvasProps) => {
 
   const canvasRef = useRef<HTMLCanvasElement>()
   const [events, setEvents] = useState<PointerEvents>({} as PointerEvents)
-  const [bind, size] = useMeasure()
+  const [bind, size, rayBounds] = useMeasure()
 
   // Allow Gatsby, Next and other server side apps to run.
   // Will output styles to reduce flickering.
@@ -100,7 +116,9 @@ export const Canvas = React.memo((props: CanvasProps) => {
       {...events}
       {...restSpread}>
       <canvas ref={canvasRef as React.MutableRefObject<HTMLCanvasElement>} style={{ display: 'block' }} />
-      {canvasRef.current && <IsReady {...props} size={size} canvas={canvasRef.current} setEvents={setEvents} />}
+      {canvasRef.current && (
+        <IsReady {...props} size={size} rayBounds={rayBounds} canvas={canvasRef.current} setEvents={setEvents} />
+      )}
     </div>
   )
 })


### PR DESCRIPTION
This an alternative approach to calculating the client bounds in relation to ray casting. It is made in effort to solve for additional use-cases referenced in https://github.com/react-spring/react-three-fiber/issues/219

The solution is to have a scroll event listener that sets a flag if the scroll event contains the canvas. Note that no reflow calculations happen inside the scroll listener. Then, mouse/pointer events will check if the flag has been set. If so, one recalculation is made.

I've setup some various test cases that can be seen here:
https://codesandbox.io/embed/react-three-fiber-scroll-bug-d7pmp