### PR TITLE
Check args for Object3D.

### DIFF
--- a/src/reconciler.tsx
+++ b/src/reconciler.tsx
@@ -337,9 +337,6 @@ const Renderer = Reconciler({
     if (instance.__instance && newProps.object && newProps.object !== instance) {
       // <instance object={...} /> where the object reference has changed
       switchInstance(instance, type, newProps, fiber)
-    } else if (instance.isObject3D) {
-      // Common Threejs scene object
-      applyProps(instance, newProps, oldProps, true)
     } else {
       // This is a data object, let's extract critical information about it
       const { args: argsNew = [], ...restNew } = newProps


### PR DESCRIPTION
There are helpers in three JS which inherited from Object3D, but they take different data (not only geometry and material) as constructor arguments (like [GridHelper](https://threejs.org/docs/index.html#api/en/helpers/GridHelper) ). So `args` should be checked for Object3D type also.