### PR TITLE
Fix examples

### DIFF
--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -68,7 +68,7 @@ module.exports = mode => {
         '../../../build/three.module.js': path.resolve('./resources/three.js'),
         'react-spring/three': createAlias('react-spring/src/targets/three', 'react-spring/three'),
         'react-use-gesture': createAlias('react-use-gesture/index.js', 'react-use-gesture'),
-        'react-use-measure': createAlias('react-use-measure/src/web', '../node_modules/react-use-measure'),
+        //'react-use-measure': createAlias('react-use-measure/src/web', '../node_modules/react-use-measure'),
         //'pointer-events-polyfill': createAlias('pointer-events-polyfill/dist/pep.js', 'pointer-events-polyfill'),
       },
     },


### PR DESCRIPTION
I've got an error, that `react-use-measure` could not be found when I was trying to start the examples.
It works again when I comment out the alias for `react-use-measure` in the webpack config.