### PR TITLE
Fix type of useLoader first param

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,6 +47,7 @@
       ],
       "rules": {
         "import/no-unresolved": "off",
+        "import/named": "off",
         "no-useless-constructor": "off",
         "@typescript-eslint/no-useless-constructor": "error",
         "@typescript-eslint/no-namespace": "off",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -92,16 +92,25 @@ function prune(props: any) {
   return reducedProps
 }
 
-export function useLoader<T>(Proto: THREE.Loader, url: string | string[], extensions?: Extensions): T {
+export interface Loader<T> extends THREE.Loader {
+  load(
+    url: string,
+    onLoad?: (result: T) => void,
+    onProgress?: (event: ProgressEvent) => void,
+    onError?: (event: ErrorEvent) => void
+  ): unknown
+}
+
+export function useLoader<T>(Proto: new () => Loader<T>, url: string | string[], extensions?: Extensions): T {
   const loader = useMemo(() => {
     // Construct new loader
-    const temp = new (Proto as any)()
+    const temp = new Proto()
     // Run loader extensions
     if (extensions) extensions(temp)
     return temp
   }, [Proto])
   // Use suspense to load async assets
-  let results = usePromise<LoaderData>(
+  const results = usePromise<LoaderData>(
     (Proto: THREE.Loader, url: string | string[]) => {
       const urlArray = Array.isArray(url) ? url : [url]
       return Promise.all(


### PR DESCRIPTION
Examples and a constructor call in useLoader body suggest that useLoader accepts a Loader class, not an instance.

```jsx
// one of the examples
useLoader(GLTFLoader, url, loader => {
  const dracoLoader = new DRACOLoader()
  dracoLoader.setDecoderPath('/draco-gltf/')
  loader.setDRACOLoader(dracoLoader)
})
```

Initially, I wanted to go with `new () => THREE.Loader`, but THREE.Loader doesn't have a `load` method (lol).

DRACOLoader, GLTFLoader and TextureLoader have similar load methods, so I have added a generic type that fits all of them and may provide some inference 👇

![image](https://user-images.githubusercontent.com/15332326/69102300-4346af00-0a62-11ea-8269-6b7dc6dfd896.png)

---

TLDR:

![image](https://user-images.githubusercontent.com/15332326/69102357-79842e80-0a62-11ea-8c46-4d443c61bdb8.png)

