### PR TITLE
fix ResizeObserver polyfill check

### DIFF
--- a/src/targets/web/canvas.tsx
+++ b/src/targets/web/canvas.tsx
@@ -64,7 +64,7 @@ export const Canvas = React.memo((props: CanvasProps) => {
     resize || {
       scroll: true,
       debounce: { scroll: 50, resize: 0 },
-      polyfill: typeof window === 'undefined' ? ResizeObserver : undefined,
+      polyfill: typeof window === 'undefined' || !window.ResizeObserver ? ResizeObserver : undefined,
     }
   )
 


### PR DESCRIPTION
I noticed that the check for `window.ResizeObserver` was broken – the polyfill was never used if there was any `window` at all.

I don't think anyone would ever notice unless they were using a browser that doesn't have ResizeObserver yet (such as Safari)