### PR TITLE
Fix useLoader for non-object data

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -118,9 +118,11 @@ export function useLoader<T>(Proto: new () => Loader<T>, url: string | string[],
           url =>
             new Promise(res =>
               loader.load(url, (data: any) => {
-                const objects: any[] = []
-                if (data.scene) data.scene.traverse((props: any) => objects.push(prune(props)))
-                data.__$ = objects
+                if (data.scene) {
+                  const objects: any[] = []
+                  data.scene.traverse((props: any) => objects.push(prune(props)))
+                  data.__$ = objects
+                }
                 res(data)
               })
             )


### PR DESCRIPTION
Some loaders can return data that isn't of type `object` (for example `THREE.FileLoader`). This change only assigns `__$` to `data` when `data` has a `scene` property.

Relevant issue: https://github.com/react-spring/react-three-fiber/issues/254