### PR TITLE
Fix Canvas props

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -94,7 +94,6 @@ export type CanvasProps = {
   >
   raycaster?: Partial<THREE.Raycaster> & { filter?: FilterFunction }
   pixelRatio?: number
-  style?: React.CSSProperties
   onCreated?: (props: CanvasContext) => Promise<any> | void
   onPointerMissed?: () => void
 }

--- a/src/targets/native/canvas.tsx
+++ b/src/targets/native/canvas.tsx
@@ -22,7 +22,7 @@ function clientXY(e: GestureResponderEvent) {
 
 const CLICK_DELTA = 20
 
-type NativeCanvasProps = Omit<CanvasProps, 'style'> & {
+export interface NativeCanvasProps extends CanvasProps {
   style?: ViewStyle
   nativeRef_EXPERIMENTAL?: React.MutableRefObject<any>
   onContextCreated?: (gl: ExpoWebGLRenderingContext) => Promise<any> | void

--- a/src/targets/web/canvas.tsx
+++ b/src/targets/web/canvas.tsx
@@ -37,7 +37,9 @@ const IsReady = React.memo(
 
 const defaultStyles: React.CSSProperties = { position: 'relative', width: '100%', height: '100%', overflow: 'hidden' }
 
-export const Canvas = React.memo((props: CanvasProps) => {
+export interface WebCanvasProps extends CanvasProps, Omit<React.ComponentProps<'div'>, 'children'> {}
+
+export const Canvas = React.memo((props: WebCanvasProps) => {
   const {
     children,
     vr,
@@ -64,7 +66,7 @@ export const Canvas = React.memo((props: CanvasProps) => {
     resize || {
       scroll: true,
       debounce: { scroll: 50, resize: 0 },
-      polyfill: typeof window === 'undefined' || !window.ResizeObserver ? ResizeObserver : undefined,
+      polyfill: typeof window === 'undefined' || !(window as any).ResizeObserver ? ResizeObserver : undefined,
     }
   )
 


### PR DESCRIPTION
Closes #242

I've spread div props in web Canvas to match what's happening at runtime.

Interfaces support [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) so end-users can stick some more props onto them.