### PR TITLE
Updated @juggle/resize-observer import to match the next major version

### DIFF
--- a/src/targets/web/canvas.tsx
+++ b/src/targets/web/canvas.tsx
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 import * as React from 'react'
 import { useRef, useEffect, useState, useMemo } from 'react'
 import useMeasure, { RectReadOnly } from 'react-use-measure'
-import ResizeObserver from '@juggle/resize-observer'
+import { ResizeObserver } from '@juggle/resize-observer'
 import { useCanvas, CanvasProps, PointerEvents } from '../../canvas'
 
 const IsReady = React.memo(


### PR DESCRIPTION
It's not possible to consume this package without a loader that also transpiles modules in the node_modules folder, since `@juggle/resize-observer` at version 2.x doesn't export UMD or CJS builds, only ESM modules.

In the soon to be released v3 of `@juggle/resize-observer`, it will only export named exports, and will provide a UMD build by default as well as an ESM version.

Currently it supports both so this should be a non-breaking change.