### PR TITLE
Add ResizeContainer props

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,7 +57,8 @@
         "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/no-inferrable-types": "warn",
-        "@typescript-eslint/no-empty-function": "off"
+        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-empty-interface": "off"
       }
     }
   ],

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "npm run build",
     "eslint": "eslint src/**/*.{js,ts,jsx,tsx}",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "typecheck": "tsc --noEmit --strict --jsx react src/*",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false --strict --jsx react",
     "typegen": "tsc || true && prettier types/**/** --write",
     "copy": "copyfiles package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\" && cp -r types dist"
   },

--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -17,7 +17,9 @@ export type DomEvent =
   | React.WheelEvent<HTMLDivElement>
   | React.PointerEvent<HTMLDivElement>
 
-export type Intersection = THREE.Intersection & { eventObject: THREE.Object3D }
+export interface Intersection extends THREE.Intersection {
+  eventObject: THREE.Object3D
+}
 
 export type PointerEvent = DomEvent &
   Intersection & {
@@ -77,7 +79,7 @@ export type ResizeOptions = {
   scroll?: boolean
 }
 
-export type CanvasProps = {
+export interface CanvasProps {
   children: React.ReactNode
   vr?: boolean
   gl2?: boolean
@@ -96,12 +98,11 @@ export type CanvasProps = {
   >
   raycaster?: Partial<THREE.Raycaster> & { filter?: FilterFunction }
   pixelRatio?: number
-  style?: React.CSSProperties
   onCreated?: (props: CanvasContext) => Promise<any> | void
   onPointerMissed?: () => void
 }
 
-export type UseCanvasProps = CanvasProps & {
+export interface UseCanvasProps extends CanvasProps {
   gl: THREE.WebGLRenderer
   size: RectReadOnly
 }
@@ -492,6 +493,8 @@ export const useCanvas = (props: UseCanvasProps): PointerEvents => {
   // we know we are ready to compile shaders, call subscribers, etc
   const IsReady = useCallback(() => {
     const activate = () => setReady(true)
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       const result = onCreated && onCreated(state.current)
       return void (result && result.then ? result.then(activate) : activate())

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-merge-refs'

--- a/src/targets/css2d.tsx
+++ b/src/targets/css2d.tsx
@@ -3,10 +3,9 @@ export * from '../canvas'
 
 import React from 'react'
 import { CSS2DRenderer } from 'three/examples/jsm/renderers/CSS2DRenderer'
-import { ResizeContainer } from './shared/web/ResizeContainer'
-import { CanvasProps } from '../canvas'
+import { ResizeContainer, ResizeContainerProps } from './shared/web/ResizeContainer'
 
-export const Canvas = React.memo(({ children, ...props }: CanvasProps) => (
+export const Canvas = React.memo(({ children, ...props }: ResizeContainerProps) => (
   <ResizeContainer
     {...props}
     renderer={() => new CSS2DRenderer()}

--- a/src/targets/css3d.tsx
+++ b/src/targets/css3d.tsx
@@ -3,10 +3,9 @@ export * from '../canvas'
 
 import React from 'react'
 import { CSS3DRenderer } from 'three/examples/jsm/renderers/CSS3DRenderer'
-import { ResizeContainer } from './shared/web/ResizeContainer'
-import { CanvasProps } from '../canvas'
+import { ResizeContainer, ResizeContainerProps } from './shared/web/ResizeContainer'
 
-export const Canvas = React.memo(({ children, ...props }: CanvasProps) => (
+export const Canvas = React.memo(({ children, ...props }: ResizeContainerProps) => (
   <ResizeContainer
     {...props}
     renderer={() => new CSS3DRenderer()}

--- a/src/targets/native/canvas.tsx
+++ b/src/targets/native/canvas.tsx
@@ -22,7 +22,7 @@ function clientXY(e: GestureResponderEvent) {
 
 const CLICK_DELTA = 20
 
-type NativeCanvasProps = Omit<CanvasProps, 'style'> & {
+interface NativeCanvasProps extends CanvasProps {
   style?: ViewStyle
   nativeRef_EXPERIMENTAL?: React.MutableRefObject<any>
   onContextCreated?: (gl: ExpoWebGLRenderingContext) => Promise<any> | void

--- a/src/targets/svg.tsx
+++ b/src/targets/svg.tsx
@@ -5,10 +5,9 @@ export * from './shared/web/Dom'
 import { Color } from 'three'
 import React from 'react'
 import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer'
-import { ResizeContainer } from './shared/web/ResizeContainer'
-import { CanvasProps } from '../canvas'
+import { ResizeContainer, ResizeContainerProps } from './shared/web/ResizeContainer'
 
-export const Canvas = React.memo(({ children, ...props }: CanvasProps) => (
+export const Canvas = React.memo(({ children, ...props }: ResizeContainerProps) => (
   <ResizeContainer
     {...props}
     renderer={() => {

--- a/src/targets/web.tsx
+++ b/src/targets/web.tsx
@@ -4,10 +4,9 @@ export * from './shared/web/Dom'
 
 import { WebGLRenderer } from 'three'
 import React, { useRef } from 'react'
-import { ResizeContainer } from './shared/web/ResizeContainer'
-import { CanvasProps } from '../canvas'
+import { ResizeContainer, ResizeContainerProps } from './shared/web/ResizeContainer'
 
-export const Canvas = React.memo(({ children, ...props }: CanvasProps) => {
+export const Canvas = React.memo(({ children, ...props }: ResizeContainerProps) => {
   const canvasRef = useRef<HTMLCanvasElement>()
   return (
     <ResizeContainer

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "noImplicitThis": false,
     "baseUrl": "./src",
     "paths": {
-      "react-three-fiber": ["./"],
+      "react-three-fiber": ["./"]
     }
   },
   "include": ["./src", "extras"],


### PR DESCRIPTION
Fixes https://github.com/react-spring/react-three-fiber/issues/242 on v4.

### Additional changes

- Fix package.json typecheck script
  Previously, it printed `error TS6053: File 'src/*.ts' not found.`

- Disable "@typescript-eslint/no-empty-interface"
  I'd like to use interfaces instead of intersections (&) to get shorter error messages and make interface merging in user code possible. The rule has a configuration option that would probably make it okay, but I figured disabling it is just as good.

- Add declarations.d.ts to tell TS we don't have types for react-merge-refs.


