### PR TITLE
Fix useLoader result types when multiple files loading

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -100,8 +100,12 @@ export interface Loader<T> extends THREE.Loader {
     onError?: (event: ErrorEvent) => void
   ): unknown
 }
-
-export function useLoader<T>(Proto: new () => Loader<T>, url: string | string[], extensions?: Extensions): T {
+type LoaderResult<T> = T extends any[] ? Loader<T[number]> : Loader<T>
+export function useLoader<T>(
+  Proto: new () => LoaderResult<T>,
+  url: T extends any[] ? string[] : string,
+  extensions?: Extensions
+): T {
   const loader = useMemo(() => {
     // Construct new loader
     const temp = new Proto()


### PR DESCRIPTION
about https://github.com/react-spring/react-three-fiber/issues/261

I've change the argument by judging whether the result of useLoader is an array
