### PR TITLE
Make renderer optional in ResizeContainer props

### DIFF
--- a/src/targets/shared/web/ResizeContainer.tsx
+++ b/src/targets/shared/web/ResizeContainer.tsx
@@ -14,7 +14,7 @@ export interface ContainerProps extends CanvasProps, React.HTMLAttributes<HTMLDi
 }
 
 export interface ResizeContainerProps extends CanvasProps, ContainerProps {
-  renderer: () => Renderer | undefined | null
+  renderer?: () => Renderer | undefined | null
   effects?: (renderer: any, parent: HTMLDivElement) => () => any
   preRender?: React.ReactNode
 }


### PR DESCRIPTION
Fixes half of https://github.com/react-spring/react-three-fiber/issues/268 and https://github.com/react-spring/react-three-fiber/pull/258#issuecomment-573124179 @drcmda @lennerd