### PR TITLE
Emit web.d.ts, svg.d.ts and native.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "eslint": "eslint src/**/*.{js,ts,jsx,tsx}",
     "test": "echo \"Error: no test specified\" && exit 1",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false --strict --jsx react",
-    "typegen": "tsc || true && prettier types/**/** --write",
+    "typegen": "tsc && mv dist/src/* dist && rm -rf dist/src || true",
     "typegen:components": "npx ts-node src/components/generateExports.ts",
-    "copy": "copyfiles package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\" && mv dist/src/* dist && rm -rf dist/src && cp -r types dist",
+    "copy": "copyfiles package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\"",
     "pack-dist": "cd dist && yarn pack && mv *.tgz .."
   },
   "husky": {


### PR DESCRIPTION
## Problem

> Importing a specific renderer directly such as "react-three-fiber/svg" or "react-three-fiber/web" gives an error that no declaration files could be found.

_mentioned in https://github.com/react-spring/react-three-fiber/issues/268_

## What I did

Write missing .d.ts files for targets with a rollup plugin.

![image](https://user-images.githubusercontent.com/15332326/72201389-bd3c5880-3453-11ea-8b6b-74d646f8c9eb.png)

## Long story

As I mentioned in a DM, I had an idea to use rollup to emit the types.

Tried `rollup-plugin-ts`.
Emitted `dist` looked pretty well

![image](https://user-images.githubusercontent.com/15332326/72201207-dfcd7200-3451-11ea-8ec1-fd1355c1cf78.png)

But the build time grew by a factor of 10 😞 

```
./src/targets/web → dist/web.js...

Computed sizes of "dist\\web.js" with "esm" format
  bundler parsing size: 34,072 B
  browser parsing size (minified with terser): 19,513 B
  download size (minified and gzipped): 7,048 B
  treeshaked with rollup with production NODE_ENV and minified: 14,985 B  
    import statements size of it: 856 B
  treeshaked with webpack in production mode: 17,151 B

created dist/web.js in 11.9s

[...]

created dist/components.js in 16.6s

./src/components → dist/components.cjs.js...

Computed sizes of "dist\\components.cjs.js" with "cjs" format
  bundler parsing size: 20,820 B
  browser parsing size (minified with terser): 18,242 B
  download size (minified and gzipped): 3,502 B

created dist/components.cjs.js in 17.3s
$ copyfiles package.json readme.md LICENSE dist && json -I -f dist/package.json -e "this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;"json: updated "dist/package.json" in-place
Done in 121.32s.
```

and upon further inspection turned out to be broken

![image](https://user-images.githubusercontent.com/15332326/72201267-62eec800-3452-11ea-8f5c-1305e87c0d8a.png)

The problem I wanted `rollup-plugin-ts` to solve is emitting the types for the targets.
`tsc` emits them already in a fraction of time, but we need to point to _targets_ directory from dist.
Then it hit me.

