### PR TITLE
added collapsable={false} to native canvas target.

### DIFF
--- a/src/targets/native/canvas.tsx
+++ b/src/targets/native/canvas.tsx
@@ -69,7 +69,7 @@ const IsReady = React.memo(({ gl, ...props }: NativeCanvasProps & { gl: any; siz
     []
   )
 
-  return <View {...panResponder.panHandlers} style={StyleSheet.absoluteFill} />
+  return <View {...panResponder.panHandlers} style={StyleSheet.absoluteFill} collapsable={false} />
 })
 
 export const Canvas = React.memo((props: NativeCanvasProps) => {


### PR DESCRIPTION
On a React Native project running on Android, none of the pointer events are fired. This is due to a React Native specific optimization, http://facebook.github.io/react-native/docs/view.html#collapsable.

This is easily fixed by adding collapsable={false} to wrapping View component in the native canvas target.