### PR TITLE
Update type of props.gl passed into WebGLRenderer

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -90,7 +90,7 @@ export interface CanvasProps {
   invalidateFrameloop?: boolean
   updateDefaultCamera?: boolean
   noEvents?: boolean
-  gl?: Partial<THREE.WebGLRenderer>
+  gl?: Partial<THREE.WebGLRendererParameters>
   camera?: Partial<
     ReactThreeFiber.Object3DNode<THREE.Camera, typeof THREE.Camera> &
       ReactThreeFiber.Object3DNode<THREE.PerspectiveCamera, typeof THREE.PerspectiveCamera> &


### PR DESCRIPTION
Per conversation in Spectrum [here](https://spectrum.chat/react-three-fiber/general/how-to-set-premultipliedalpha~d1b0231e-6fdf-47f4-b9e1-776a264e32b6). Seems pretty straightforward. Sorry again for the delay. Please let me know if I missed something! 🙏 