### PR TITLE
add missing react-merge-refs dependency

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -9,6 +9,7 @@
     "cannon": "^0.6.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-merge-refs": "^1.0.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.3.0",
     "react-spring": "^8.0.27",

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -9259,6 +9259,11 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
+react-merge-refs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.0.0.tgz#d6b297b9a62a266460a3c0d8b9d920731d8bbe63"
+  integrity sha512-VkvWuCR5VoTjb+VYUcOjkFo66HDv1Hw8VjKcwQtWr2lJnT8g7epRRyfz8+Zkl2WhwqNeqR0gIe0XYrBa9ePeXg==
+
 react-refresh@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.7.2.tgz#f30978d21eb8cac6e2f2fde056a7d04f6844dd50"


### PR DESCRIPTION
I noticed that building examples failed with an error about this dependency missing, so I added it. 

I'm unfamiliar with how the dependency is used, so it's unclear if there was another/better thing to do than just adding the dependency.