### PR TITLE
Throw if text found in tree in Suspense boundary

### DIFF
--- a/src/reconciler.tsx
+++ b/src/reconciler.tsx
@@ -389,6 +389,11 @@ const Renderer = Reconciler({
       invalidateInstance(instance)
     }
   },
+  hideTextInstance() {
+    throw new Error(
+      'Text is not allowed in the react-three-fibre tree. You may have extraneous whitespace between components.'
+    )
+  },
   getPublicInstance(instance: any) {
     return instance
   },


### PR DESCRIPTION
Closes issue #321

I'm not sure if this is the preferred fix, but this will throw if a Suspense component 'finishes loading' with text in the tree. It makes it easier to diagnose these kinds of typos:

![image](https://user-images.githubusercontent.com/13504878/77755251-cadda380-707c-11ea-939c-c846a6ce2de1.png)

Note the space before the `{props.children}`