### PR TITLE
specify type for dispose on Object3DNode

### DIFF
--- a/src/three-types.ts
+++ b/src/three-types.ts
@@ -52,6 +52,7 @@ export declare namespace ReactThreeFiber {
       scale?: Vector3
       rotation?: Euler
       matrix?: Matrix4
+      dispose?: (() => void) | null
     }
   > &
     ReactThreeFiber.Events


### PR DESCRIPTION
specify type for `dispose` on `Object3DNode`, allows a function or null