### PR TITLE
Fix readme typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@
 
 #### Why?
 
-Building dynamic scene graphs declaratively with re-usable components makes dealing with Threejs easier and brings order and sanity to your codebase. These components react to state changes, are interactive out of the box and can tap into Reacts infitine eco system.
+Building dynamic scene graphs declaratively with re-usable components makes dealing with Threejs easier and brings order and sanity to your codebase. These components react to state changes, are interactive out of the box and can tap into React's infinite ecosystem.
 
 #### Does it have limitations?
 


### PR DESCRIPTION
# Description

Fixes typos in readme:
1. Changes _Reacts_ to the possessive _React's_
2. Fixes typo of _infinite_
3. Combines _eco system_ into _ecosystem_