### PR TITLE
fix: let global effects call `invalidate`

### DIFF
--- a/src/reconciler.tsx
+++ b/src/reconciler.tsx
@@ -66,9 +66,9 @@ export function renderGl(
   return repeat
 }
 
-let running = false
+let queued = false
 function renderLoop(timestamp: number) {
-  running = true
+  queued = false
   let repeat = 0
 
   // Run global effects
@@ -86,8 +86,6 @@ function renderLoop(timestamp: number) {
     // Tail call effects, they are called when rendering stops
     globalTailEffects.forEach((effect) => effect(timestamp))
   }
-  // Flag end of operation
-  running = false
 }
 
 export function invalidate(state: React.MutableRefObject<CanvasContext> | boolean = true, frames: number = 2) {
@@ -96,8 +94,8 @@ export function invalidate(state: React.MutableRefObject<CanvasContext> | boolea
     if (state.current.vr) return
     state.current.frames = frames
   }
-  if (!running) {
-    running = true
+  if (!queued) {
+    queued = true
     requestAnimationFrame(renderLoop)
   }
 }


### PR DESCRIPTION
In `@react-spring/three` v9, the frameloop calls `invalidate` from within a global effect (r3f's terminology), but that call is ignored because of the broken logic in `renderLoop`. More specifically, the `running` variable is preventing rAF calls that would've otherwise kept the render loop going.

This fix makes sure to keep prevention of multiple rAF calls. 👍 

**Note:** react-spring v9.0.0-rc.3 won't work without this commit.