### PR TITLE
fix: avoid calling rAF from renderLoop if already called

### DIFF
--- a/src/reconciler.tsx
+++ b/src/reconciler.tsx
@@ -81,11 +81,12 @@ function renderLoop(timestamp: number) {
       repeat = renderGl(state, timestamp, repeat)
   })
 
-  if (repeat !== 0) return requestAnimationFrame(renderLoop)
-  else {
-    // Tail call effects, they are called when rendering stops
-    globalTailEffects.forEach((effect) => effect(timestamp))
+  if (repeat !== 0) {
+    return invalidate(false)
   }
+
+  // Tail call effects, they are called when rendering stops
+  globalTailEffects.forEach((effect) => effect(timestamp))
 }
 
 export function invalidate(state: React.MutableRefObject<CanvasContext> | boolean = true, frames: number = 2) {


### PR DESCRIPTION
This fixes a major performance issue when using `@react-spring/three`