### PR TITLE
Add Vector2 to three-types

### DIFF
--- a/src/three-types.ts
+++ b/src/three-types.ts
@@ -14,6 +14,7 @@ type Args<T> = T extends new (...args: any) => any ? ConstructorParameters<T> : 
 export declare namespace ReactThreeFiber {
   type Euler = THREE.Euler | Parameters<THREE.Euler['set']>
   type Matrix4 = THREE.Matrix4 | Parameters<THREE.Matrix4['set']>
+  type Vector2 = THREE.Vector2 | Paramaters<THREE.Vector2['set']>
   type Vector3 = THREE.Vector3 | Parameters<THREE.Vector3['set']>
   type Color = THREE.Color | number | string // Parameters<T> will not work here because of multiple function signatures in three.js types
   type Layers = THREE.Layers | Parameters<THREE.Layers['set']>


### PR DESCRIPTION
Add Vector2 to make glitch effects props available in Glitch (in react-postprocessing).

I am writing a `react-postprocessing` Glitch effect lib:

```jsx
import { GlitchEffect } from 'postprocessing'
import { ForwardRefExoticComponent, useMemo, useImperativeHandle, forwardRef } from 'react'
import { ReactThreeFiber } from 'react-three-fiber'

interface GlitchProps extends GlitchEffect {
  delay: ReactThreeFiber.Vector2
}

const Glitch: ForwardRefExoticComponent<GlitchEffect> = forwardRef((props: GlitchProps, ref) => {
  const effect = useMemo(() => new GlitchEffect(props), [props])

  useImperativeHandle(ref, () => effect, [effect])

  return null
})

export default Glitch
```

And `Vector2` is not present. This PR will add Vector2 type to r3f so I can use it later.

Here's what I want to add:

```ts
type Vector2 = THREE.Vector2 | Paramaters<THREE.Vector2['set']>
```

