### PR TITLE
Fix crash with createPortal.

### DIFF
--- a/src/reconciler.tsx
+++ b/src/reconciler.tsx
@@ -312,7 +312,8 @@ function removeChild(parentInstance: any, child: any) {
       parentInstance.remove(child)
     } else {
       child.parent = null
-      parentInstance.__objects = parentInstance.__objects.filter((x: any) => x !== child)
+      if (parentInstance.__objects)
+        parentInstance.__objects = parentInstance.__objects.filter((x: any) => x !== child)
       // Remove attachment
       if (child.attach) parentInstance[child.attach] = null
       else if (child.attachArray)


### PR DESCRIPTION
It fixes a crash when we use portals and (at least) this change happend in the scene tree:

Going from:
A <--portal--- B <----portal--- C
To:
D <--portal--- B <----portal--- C

(the replacement of A by D as a parentGroup of B is triggered by a prop change).
