### PR TITLE
Fixing white spots on white backgrounds in examples

### DIFF
--- a/examples/src/demos/index.js
+++ b/examples/src/demos/index.js
@@ -20,16 +20,22 @@ const Dom = { descr: '', tags: [], Component: lazy(() => import('./dev/Dom')), d
 //const CSS2DRenderer = { descr: '', tags: [], Component: lazy(() => import('./dev/CSS2DRenderer')), dev: true }
 //const CSS3DRenderer = { descr: '', tags: [], Component: lazy(() => import('./dev/CSS3DRenderer')), dev: true }
 const Selection = { descr: '', tags: [], Component: lazy(() => import('./dev/Selection')), dev: true }
-const Pointcloud = { descr: '', tags: [], Component: lazy(() => import('./dev/Pointcloud')), dev: true }
-const Reparenting = { descr: '', tags: [], Component: lazy(() => import('./dev/Reparenting')), dev: true }
-const MultiRender = { descr: '', tags: [], Component: lazy(() => import('./dev/MultiRender')), dev: true }
+const Pointcloud = { descr: '', tags: [], Component: lazy(() => import('./dev/Pointcloud')), dev: true, bright: true }
+const Reparenting = { descr: '', tags: [], Component: lazy(() => import('./dev/Reparenting')), dev: true, bright: true }
+const MultiRender = { descr: '', tags: [], Component: lazy(() => import('./dev/MultiRender')), dev: true, bright: true }
 const MultiScene = { descr: '', tags: [], Component: lazy(() => import('./dev/MultiScene')), dev: true }
 const Hud = { descr: '', tags: [], Component: lazy(() => import('./dev/Hud')), dev: true }
-const InstancedMesh = { descr: '', tags: [], Component: lazy(() => import('./dev/InstancedMesh')), dev: true }
+const InstanceMesh = {
+  descr: '',
+  tags: [],
+  Component: lazy(() => import('./dev/InstancedMesh')),
+  dev: true,
+  bright: true,
+}
 const GltfAnimation = { descr: '', tags: [], Component: lazy(() => import('./dev/GltfAnimation')), dev: true }
 //const VR = { descr: '', tags: [], Component: lazy(() => import('./dev/VR')), dev: true }
 const ShaderMaterial = { descr: '', tags: [], Component: lazy(() => import('./dev/ShaderMaterial')), dev: true }
-const Suspense = { descr: '', tags: [], Component: lazy(() => import('./dev/Suspense')), dev: true }
+const Suspense = { descr: '', tags: [], Component: lazy(() => import('./dev/Suspense')), dev: true, bright: true }
 const SelectiveBloom = { descr: '', tags: [], Component: lazy(() => import('./dev/SelectiveBloom')), dev: true }
 const Scroll = { descr: '', tags: [], Component: lazy(() => import('./dev/Scroll')), dev: true }
 const Lines = { descr: '', tags: [], Component: lazy(() => import('./dev/Lines')), dev: true }


### PR DESCRIPTION
I wanted to open this PR to fix the white spots on white backgrounds. But I think the `Modifications` task is modifying my commit and breaking the `const InstanceMesh = {` formatting. (This is a guess).

How can this be avoided? My code does not have these line breaks. See below:
<img width="882" alt="Screenshot 2020-05-31 at 14 56 36" src="https://user-images.githubusercontent.com/448410/83352870-f2880b00-a34e-11ea-89cb-c95437f0d218.png">

Anyway, here is the fix screenshots.

Before:
<img width="266" alt="Screenshot 2020-05-31 at 14 09 08" src="https://user-images.githubusercontent.com/448410/83351960-873b3a80-a348-11ea-94a4-e3d12f289d05.png">

After:
<img width="231" alt="Screenshot 2020-05-31 at 14 26 17" src="https://user-images.githubusercontent.com/448410/83352296-b783d880-a34a-11ea-8b86-cc5e3eace854.png">
