### PR TITLE
Fix Physics.js warnings

### DIFF
--- a/examples/src/demos/Physics.js
+++ b/examples/src/demos/Physics.js
@@ -1,7 +1,7 @@
 import * as CANNON from 'cannon'
 import * as THREE from 'three'
 import React, { useRef, useEffect, useState, useContext } from 'react'
-import { Canvas, useFrame, addEffect, useThree } from 'react-three-fiber'
+import { Canvas, useFrame } from 'react-three-fiber'
 
 // Cannon-world context provider
 const context = React.createContext()
@@ -33,6 +33,7 @@ export function useCannon({ ...props }, fn, deps = []) {
     world.addBody(body)
     // Remove body on unmount
     return () => world.removeBody(body)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps)
   useFrame(() => {
     if (ref.current) {
@@ -46,7 +47,7 @@ export function useCannon({ ...props }, fn, deps = []) {
 
 function Plane({ position }) {
   // Register plane as a physics body with zero mass
-  const ref = useCannon({ mass: 0 }, body => {
+  const ref = useCannon({ mass: 0 }, (body) => {
     body.addShape(new CANNON.Plane())
     body.position.set(...position)
   })
@@ -61,7 +62,7 @@ function Plane({ position }) {
 function Box({ position }) {
   const [hovered, set] = useState(false)
   // Register box as a physics body with mass
-  const ref = useCannon({ mass: 100000 }, body => {
+  const ref = useCannon({ mass: 100000 }, (body) => {
     body.addShape(new CANNON.Box(new CANNON.Vec3(1, 1, 1)))
     body.position.set(...position)
   })
@@ -81,7 +82,10 @@ export default function App() {
   return (
     <Canvas
       camera={{ position: [0, 0, 15] }}
-      onCreated={({ gl }) => ((gl.shadowMap.enabled = true), (gl.shadowMap.type = THREE.PCFSoftShadowMap))}>
+      onCreated={({ gl }) => {
+        gl.shadowMap.enabled = true
+        gl.shadowMap.type = THREE.PCFSoftShadowMap
+      }}>
       <ambientLight intensity={0.5} />
       <spotLight intensity={0.6} position={[30, 30, 50]} angle={0.2} penumbra={1} castShadow />
       <Provider>


### PR DESCRIPTION
<img width="1438" alt="Screenshot 2020-06-01 at 09 18 35" src="https://user-images.githubusercontent.com/448410/83390028-67ac1c80-a3f1-11ea-9ffe-6515425530e8.png">

I started wrapping some of this Cannon stuff into `useCallback` to suppress the warnings but instead, I will just opt for `// eslint-disable-next-line react-hooks/exhaustive-deps`

I have not played much with hooks tbh, I did not touch React for around 3 years, hence why I am super excited to work more with this lib, looks really really cool. 