### PR TITLE
Fix SelectiveBloom.js warnings

### DIFF
--- a/examples/src/demos/dev/SelectiveBloom.js
+++ b/examples/src/demos/dev/SelectiveBloom.js
@@ -41,7 +41,7 @@ function Bloom({ children }) {
     composer.current = new EffectComposer(gl)
     composer.current.addPass(new RenderPass(scene.current, camera))
     composer.current.addPass(new UnrealBloomPass(new THREE.Vector2(size.width, size.height), 1.5, 1, 0))
-  }, [])
+  }, [gl, camera, size.height, size.width])
   useEffect(() => void composer.current.setSize(size.width, size.height), [size])
   useFrame(() => composer.current.render(), 1)
   return <scene ref={scene}>{children}</scene>


### PR DESCRIPTION
In the master branch, this example does not seem to animate, do you remember if this was always the case?

<img width="479" alt="Screenshot 2020-06-01 at 10 34 00" src="https://user-images.githubusercontent.com/448410/83391394-b2c72f00-a3f3-11ea-857b-0202818c6e29.png">
