### PR TITLE
Adding initial learning/overview resources to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,12 @@ ReactDOM.render(
 - 👇 [react-use-gesture](https://github.com/react-spring/react-use-gesture), mouse/touch gestures
 - 🧪 [react-three-gui](https://github.com/ueno-llc/react-three-gui), GUI/debug tools
 
+# Introduction resources
+
+- [Bringing WebGL to React - Paul Henschel aka @0xca0a at @ReactEurope 2020](https://www.youtube.com/watch?v=YyqBdN71nFs)
+- [Animation and 3D in react-three-fiber (with Paul Henschel) — Learn With Jason](https://www.youtube.com/watch?v=1rP3nNY2hTo)
+- [Scroll, Refraction and Shader Effects in Three.js and React](https://tympanus.net/codrops/2019/12/16/scroll-refraction-and-shader-effects-in-three-js-and-react/)
+
 # News, updates, community
 
 - [@0xca0a](https://twitter.com/0xca0a)'s twitter


### PR DESCRIPTION
As a newbie to the project. I felt there is a lot of really great information on these links to help onboard new people. (If you do not want these links on the README just reject the PR).

Also, I am thinking the Wiki is not being used and we could perhaps start building it out? I saw you say you have a lot of sandboxes laying around and we could start collecting them? Plus add mini-tutorials, very common questions/faq etc all inside the wiki.