### PR TITLE
<Dom> was removed from lib and moved to Drei

### DIFF
--- a/examples/src/demos/dev/Concurrent.js
+++ b/examples/src/demos/dev/Concurrent.js
@@ -1,7 +1,8 @@
 import React, { useRef, useState, useEffect } from 'react'
 import { BoxBufferGeometry, MeshNormalMaterial } from 'three'
-import { Canvas, Dom, useFrame, useThree } from 'react-three-fiber'
+import { Canvas, useFrame, useThree } from 'react-three-fiber'
 import { Controls, useControl } from 'react-three-gui'
+import { HTML } from 'drei'
 import { unstable_LowPriority as low, unstable_runWithPriority as run } from 'scheduler'
 
 const SLOWDOWN = 1
@@ -39,8 +40,6 @@ function Blocks() {
     return () => clearInterval(handler)
   })
 
-  console.log(changeBlocks)
-
   const { viewport } = useThree()
   const width = viewport.width / 100
   const size = width / ROW
@@ -69,16 +68,14 @@ function Fps() {
     }
     last = now
   })
-  return <Dom className="fps" center ref={ref} />
+  return <HTML className="fps" center ref={ref} />
 }
 
 function Box() {
   let t = 0
   const mesh = useRef()
   const [coords] = useState(() => [rpi(), rpi(), rpi()])
-  useFrame(
-    ({ clock }) => mesh.current && mesh.current.rotation.set(coords[0] + (t += 0.01), coords[1] + t, coords[2] + t)
-  )
+  useFrame(() => mesh.current && mesh.current.rotation.set(coords[0] + (t += 0.01), coords[1] + t, coords[2] + t))
   return <mesh ref={mesh} geometry={geom} material={matr} scale={[2, 2, 2]} />
 }
 


### PR DESCRIPTION
The concurrent demo is broken since `<Dom>` was moved to Drei as `<HTML>`.

Currently, it shows this error:
<img width="730" alt="Screenshot 2020-06-06 at 09 21 41" src="https://user-images.githubusercontent.com/448410/83938728-53906280-a7d7-11ea-8ddb-e23de5963b8f.png">
