### PR TITLE
Extended Click Event Handlers

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -488,8 +488,8 @@ export const useCanvas = (props: UseCanvasProps): DomEventHandlers => {
         const eventObject = data.eventObject
         const handlers = (eventObject as any).__handlers
         if (handlers && handlers[name]) {
-          // Forward all events back to their respective handlers with the exception of click,
-          // which must must the initial target
+          // Forward all events back to their respective handlers with the exception of click events,
+          // which must use the initial target
           if (
             (name !== 'click' && name !== 'contextMenu' && name !== 'doubleClick') ||
             state.current.initialHits.includes(eventObject)

--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -115,6 +115,8 @@ export interface UseCanvasProps extends CanvasProps {
 
 export type DomEventHandlers = {
   onClick(e: any): void
+  onContextMenu(e: any): void
+  onDoubleClick(e: any): void
   onWheel(e: any): void
   onPointerDown(e: any): void
   onPointerUp(e: any): void
@@ -488,7 +490,12 @@ export const useCanvas = (props: UseCanvasProps): DomEventHandlers => {
         if (handlers && handlers[name]) {
           // Forward all events back to their respective handlers with the exception of click,
           // which must must the initial target
-          if (name !== 'click' || state.current.initialHits.includes(eventObject)) handlers[name](data)
+          if (
+            (name !== 'click' && name !== 'contextMenu' && name !== 'doubleClick') ||
+            state.current.initialHits.includes(eventObject)
+          ) {
+            handlers[name](data)
+          }
         }
       })
       // If a click yields no results, pass it back to the user as a miss
@@ -496,7 +503,8 @@ export const useCanvas = (props: UseCanvasProps): DomEventHandlers => {
         state.current.initialClick = [event.clientX, event.clientY]
         state.current.initialHits = hits.map((hit) => hit.eventObject)
       }
-      if (name === 'click' && !hits.length && onPointerMissed) {
+
+      if ((name === 'click' || name === 'contextMenu' || name === 'doubleClick') && !hits.length && onPointerMissed) {
         if (calculateDistance(event) <= 2) onPointerMissed()
       }
     },
@@ -506,6 +514,8 @@ export const useCanvas = (props: UseCanvasProps): DomEventHandlers => {
   useMemo(() => {
     state.current.events = {
       onClick: handlePointer('click'),
+      onContextMenu: handlePointer('contextMenu'),
+      onDoubleClick: handlePointer('doubleClick'),
       onWheel: handlePointer('wheel'),
       onPointerDown: handlePointer('pointerDown'),
       onPointerUp: handlePointer('pointerUp'),

--- a/src/reconciler.tsx
+++ b/src/reconciler.tsx
@@ -113,9 +113,9 @@ export function applyProps(instance: any, newProps: any, oldProps: any = {}, acc
     // Event-handlers ...
     //   are functions, that
     //   start with "on", and
-    //   contain the name "pointer", or "wheel", or "click"
+    //   contain the name "Pointer", "Click", "ContextMenu", or "Wheel"
     if (is.fun(newProps[key]) && key.startsWith('on')) {
-      return key.includes('Pointer') || key.includes('Click') || key.includes('Wheel')
+      return key.includes('Pointer') || key.includes('Click') || key.includes('ContextMenu') || key.includes('Wheel')
     }
   })
   const leftOvers = accumulative ? Object.keys(oldProps).filter((key) => newProps[key] === void 0) : []

--- a/src/three-types.ts
+++ b/src/three-types.ts
@@ -22,6 +22,8 @@ export declare namespace ReactThreeFiber {
 
   export type EventHandlers = {
     onClick?: (event: MouseEvent) => void
+    onContextMenu?: (event: MouseEvent) => void
+    onDoubleClick?: (event: MouseEvent) => void
     onPointerUp?: (event: PointerEvent) => void
     onPointerDown?: (event: PointerEvent) => void
     onPointerOver?: (event: PointerEvent) => void


### PR DESCRIPTION
![2020-06-23_20-11-07](https://user-images.githubusercontent.com/3931162/85480355-de21e180-b58d-11ea-9f5e-dbf133c0e5fd.gif)

Following the existing examples of the `onClick` implementation, I extended the event handlers to support both `onDoubleClick` and `onContextMenu`.

The main reason for this PR is that I need to support "right-clicking" in my game. I was surprised to find that support for it didn't exist yet in R3F. The [corresponding handler in React](https://reactjs.org/docs/events.html#mouse-events) is `onContextMenu`. I looked through the discussions and didn't see any conversations about it yet, [however I did see one ](https://github.com/react-spring/react-three-fiber/discussions/499) about `onDoubleClick`. I figured I would add support for that event as well since I'll probably need it too 😉 

Please let me know if there is anything I can do to get this merged. Thanks again for this awesome library @drcmda!