### PR TITLE
Api doc update

### DIFF
--- a/api.md
+++ b/api.md
@@ -199,6 +199,8 @@ Also notice the `onPointerMissed` on the canvas element, which fires on clicks t
 ```jsx
 <mesh
   onClick={(e) => console.log('click')}
+  onContextMenu={(e) => console.log('context menu')}
+  onDoubleClick={(e) => console.log('double click')}
   onWheel={(e) => console.log('wheel spins')}
   onPointerUp={(e) => console.log('up')}
   onPointerDown={(e) => console.log('down')}

--- a/api.md
+++ b/api.md
@@ -434,7 +434,7 @@ At the moment React context [can not be readily used between two reconcilers](ht
 const forwardContext = React.createContext()
 
 function App() {
-  const state = useContext(myContext)
+  const state = useContext(forwardContext)
   return (
     <Canvas>
       <forwardContext.Provider value={state}>


### PR DESCRIPTION
Following up from 064d9a3613a595a193d7fe2b3b9c7994cc8b7b9f, I was reading the `api.md` and saw that we didn't have examples for these new events yet.

Also, I made a small correction to the `forwardContext` example. It was using `myContext` before which isn't defined and may have been confusing to the reader.