### PR TITLE
Notate that extended components use camel casing

### DIFF
--- a/api.md
+++ b/api.md
@@ -160,6 +160,7 @@ return <primitive object={mesh} position={[0, 0, 0]} />
 #### Using 3rd-party objects declaratively
 
 The `extend` function extends three-fibers catalogue of JSX elements.
+Much like any primitive, components added to the catalog via `extend` are expected to use camel casing.
 
 ```jsx
 import { extend } from 'react-three-fiber'

--- a/api.md
+++ b/api.md
@@ -159,8 +159,7 @@ return <primitive object={mesh} position={[0, 0, 0]} />
 
 #### Using 3rd-party objects declaratively
 
-The `extend` function extends three-fibers catalogue of JSX elements.
-Much like any primitive, components added to the catalog via `extend` are expected to use camel casing.
+The `extend` function extends three-fiber's catalogue of JSX elements. Components added this way can then be referenced in the scene-graph using camel casing similar to other primitives.
 
 ```jsx
 import { extend } from 'react-three-fiber'


### PR DESCRIPTION
When adding a component to a catalog via `extend()`, it may not be clear that they must be in camel case. This is conflicts with the stylistic standards of components which are pascal casing.  So it might be important to document this difference. This conversation was started in [discussion #587](https://github.com/react-spring/react-three-fiber/discussions/587).