### PR TITLE
Fix object-style shadowMap prop not correctly applied

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -565,7 +565,7 @@ export const useCanvas = (props: UseCanvasProps): DomEventHandlers => {
   useLayoutEffect(() => {
     if (shadowMap) {
       gl.shadowMap.enabled = true
-      if (typeof shadowMap === 'object') Object.assign(gl, shadowMap)
+      if (typeof shadowMap === 'object') Object.assign(gl.shadowMap, shadowMap)
       else gl.shadowMap.type = THREE.PCFSoftShadowMap
     }
     if (sRGB || colorManagement) {


### PR DESCRIPTION
Code sandbox link: https://codesandbox.io/s/r3f-shadowmap-prop-dv2jq

In the sandbox, VSM shadow maps should be selected:

```
shadowMap={{
  enabled: true,
  type: VSMShadowMap
}}
```

But the renderer is using the default type, `PCFShadowMap`, because the `enabled` and `type` props are being assigned to the `WebGLRenderer` itself, instead of to its `shadowMap` property.
