### PR TITLE
Added Typescript tricks to have labeled tuples

### DIFF
--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -73,7 +73,7 @@ export type CanvasContext = SharedCanvasContext & {
   invalidateFrameloop: boolean
   frames: number
   subscribers: Subscription[]
-  initialClick: [number, number]
+  initialClick: Parameters<(x: number, y: number) => void>
   initialHits: THREE.Object3D[]
   pointer: TinyEmitter
 }

--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 import React, { useMemo, useRef, useEffect, useState, useCallback, createContext, useLayoutEffect } from 'react'
 import { render, invalidate, applyProps, unmountComponentAtNode, renderGl } from './renderer'
 import { TinyEmitter } from 'tiny-emitter'
-import { ReactThreeFiber } from './three-types'
+import { NamedArrayTuple, ReactThreeFiber } from './three-types'
 import { RectReadOnly } from 'react-use-measure'
 
 export type Camera = THREE.OrthographicCamera | THREE.PerspectiveCamera
@@ -73,7 +73,7 @@ export type CanvasContext = SharedCanvasContext & {
   invalidateFrameloop: boolean
   frames: number
   subscribers: Subscription[]
-  initialClick: Parameters<(x: number, y: number) => void>
+  initialClick: NamedArrayTuple<(x: number, y: number) => void>
   initialHits: THREE.Object3D[]
   pointer: TinyEmitter
 }

--- a/src/three-types.ts
+++ b/src/three-types.ts
@@ -36,7 +36,7 @@ export declare namespace ReactThreeFiber {
     /** Appends this class to an array on the parent under the given name and removes it on unmount */
     attachArray?: string
     /** Adds this class to an object on the parent under the given name and deletes it on unmount */
-    attachObject?: [string, string]
+    attachObject?: Parameters<(target: string, name: string) => void>
     /** Constructor arguments */
     args?: Args<P>
     children?: React.ReactNode

--- a/src/three-types.ts
+++ b/src/three-types.ts
@@ -3,6 +3,10 @@ import { MouseEvent, PointerEvent, WheelEvent } from './canvas'
 
 export type NonFunctionKeys<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]
 export type Overwrite<T, O> = Omit<T, NonFunctionKeys<O>> & O
+/**
+ * Allows using a TS v4 labeled tuple even with older typescript versions
+ */
+export type NamedArrayTuple<T extends (...args: any) => any> = Parameters<T>
 
 /**
  * If **T** contains a constructor, @see ConstructorParameters must be used, otherwise **T**.
@@ -36,7 +40,7 @@ export declare namespace ReactThreeFiber {
     /** Appends this class to an array on the parent under the given name and removes it on unmount */
     attachArray?: string
     /** Adds this class to an object on the parent under the given name and deletes it on unmount */
-    attachObject?: Parameters<(target: string, name: string) => void>
+    attachObject?: NamedArrayTuple<(target: string, name: string) => void>
     /** Constructor arguments */
     args?: Args<P>
     children?: React.ReactNode


### PR DESCRIPTION
A trick to have labeled tuples in some types, without forcing the user to use Typescript v4.

The TS v4 solution would be:
```
attachObject?: [target: string, name: string];
```

But this would break typings for users with TS v3. An hack to have them without breaking stuff is inferring params from a function, since it works also in older typescript.

Feel free to ignore this if it's too ugly (lol)